### PR TITLE
Add new build and dev containers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,37 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+FROM ncatelli/hugo_builder:v0.29
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# This Dockerfile adds a non-root 'vscode' user with sudo access. However, for Linux,
+# this user's GID/UID must match your local user UID/GID to avoid permission issues
+# with bind mounts. Update USER_UID / USER_GID if yours is not 1000. See
+# https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Configure apt, install packages and tools
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    #
+    # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
+    && apt-get -y install git iproute2 procps lsb-release \
+    #
+    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
+    && groupadd --gid $USER_GID $USERNAME \
+    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    # [Optional] Add sudo support
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/* /go/src

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or the definition README at
+// https://github.com/microsoft/vscode-dev-containers/tree/master/containers/go
+{
+	"name": "Hugo v0.29",
+	"dockerFile": "Dockerfile",
+	"runArgs": [
+		// Uncomment the next line to use a non-root user. On Linux, this will prevent
+		// new files getting created as root, but you may need to update the USER_UID
+		// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
+		"-u", "vscode",
+		"--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"
+	],
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+	
+	// Uncomment the next line if you want to publish any ports.
+	"appPort": [
+		1313
+	],
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "go version",
+
+	// Add the IDs of extensions you want installed when the container is created in the array below.
+	"extensions": []
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,13 @@ services:
   - docker
 
 env:
-  HUGO_IMAGE: 'ncatelli/hugo_builder:v0.29'
+  HUGO_IMAGE: 'hugo_builder'
+  HUGO_VERSION: '0.29'
 
 before_install:
-  - docker pull $HUGO_IMAGE
+  - pushd scripts/hugo_builder/
+  - docker build -t $HUGO_IMAGE .
+  - popd
   - sudo apt-get install -y curl
 
 stages:
@@ -18,7 +21,7 @@ stages:
 jobs:
   include:
     - stage: "Build and Deploy"
-      script: docker run --rm -v $PWD:/work -w /work $HUGO_IMAGE /usr/local/bin/hugo
+      script: docker run --rm -e HUGO_VERSION -v $PWD:/data -w /data $HUGO_IMAGE
       deploy:
         provider: s3
         access_key_id: $AWS_ACCESS_KEY_ID

--- a/scripts/hugo_builder/Dockerfile
+++ b/scripts/hugo_builder/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:9
+
+LABEL maintainer="Nate Catelli <ncatelli@packetfire.org>"
+LABEL description="The hugo build environment for the packetfire site."
+LABEL "com.github.actions.name"="Hugo Actions"
+LABEL "com.github.actions.description"="The hugo build environment for the packetfire site."
+
+RUN apt-get update && \ 
+    apt-get install -y curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ADD entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/scripts/hugo_builder/Dockerfile
+++ b/scripts/hugo_builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:9
+FROM debian:10
 
 LABEL maintainer="Nate Catelli <ncatelli@packetfire.org>"
 LABEL description="The hugo build environment for the packetfire site."

--- a/scripts/hugo_builder/entrypoint.sh
+++ b/scripts/hugo_builder/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+set -x
+
+echo $HUGO_VERSION
+
+curl -sk "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz" -L -o /tmp/hugo.tar.gz
+tar -zxf /tmp/hugo.tar.gz -C /tmp/
+mv /tmp/hugo /usr/local/bin/hugo
+rm -rf /tmp/*
+
+sh -c "hugo $*"


### PR DESCRIPTION
# Introduction
This PR adds a local hugo_builder container to decouple builds from `ncatelli/hugo_builder`. This also adds a new vscode devcontainer, allowing dev work to happen without being dependent on the `ncatelli/hugo_builder image`.

# Linked Issues
resolves #14 
resolves #13 

# Dependencies

# Test
- [x] Tested Locally

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment

