### PR TITLE
Update to use bird_examples_docker

### DIFF
--- a/content/post/intro-to-bgp.md
+++ b/content/post/intro-to-bgp.md
@@ -1,9 +1,9 @@
 ---
 title: "Intro to BGP with BIRD"
-date: 2017-08-21T13:43:28-04:00
+date: 2020-07-13T13:43:28-04:00
 author: "Nate Catelli"
 tags: ["networking"]
-description: "An introductory tutorial on BGP using BIRD and vagrant."
+description: "An introductory tutorial on BGP using BIRD and docker."
 type: "post"
 draft: false
 ---
@@ -13,39 +13,32 @@ Border Gateway Protocol (BGP) is one of the core technologies involved in making
 
 By the end of this tutorial, you will be familiar with the core concepts of BGP and have the proper vocabulary to communicate this to another network engineer. You will also be able to use a userland routing daemon, BIRD, to establish peering sessions and begin announcing routes.
 
-I plan to achieve this using a virtualized vagrant playground which can be downloaded [here](https://github.com/ncatelli/bird_examples.git). In order to complete this tutorial you will need to install vagrant 1.6+, git and rsync.
+I plan to achieve this using a virtualized docker playground which can be downloaded [here](https://github.com/ncatelli/bird_examples.git). In order to complete this tutorial you will need to ensure you have docker and docker-compose installed.
 
 ### Setup:
 To begin, you will need to clone the repo and all submodules of the [bird_examples](https://github.com/ncatelli/bird_examples.git) project.
 
 ```bash
-ncatelli@ofet> git clone https://github.com/ncatelli/bird_examples.git
+ncatelli@ofet> git clone https://github.com/ncatelli/bird_examples_docker.git
 ncatelli@ofet> cd bird_examples
-ncatelli@ofet> git submodule init
-ncatelli@ofet> git submodule update
-ncatelli@ofet> vagrant up
+ncatelli@ofet> docker-compose up -d
 ```
 
-This should create three VMs, peer1, peer2 and peer3, all of which have BIRD installed and have peering sessions established. Don't worry if you don't know what this means yet, we will cover it shortly after we have our BGP playground set up and ready to go.
+This should create three containers (peer1, peer2 and peer3), all of which have BIRD installed and have peering sessions established. Don't worry if you don't know what this means yet, we will cover it shortly after we have our BGP playground set up and ready to go.
 
 ### Login in to your playground:
 We will start by connecting to peer1 and checking that everything was setup correctly.
 
 ```bash
-ncatelli@ofet> vagrant ssh peer1
-Linux peer1 4.9.0-3-amd64 #1 SMP Debian 4.9.30-2+deb9u2 (2017-06-26) x86_64 
-
-The programs included with the Debian GNU/Linux system are free software; the exact distribution terms for each program are described in the individual files in /usr/share/doc/*/copyright.
-Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent permitted by applicable law. 
-vagrant@peer1:~$ sudo su -
-root@peer1:~# birdc show protocols
-BIRD 1.6.3 ready.
+ncatelli@ofet> docker-compose exec peer1 bash
+root@peer1:/# birdc show protocols
+BIRD 1.6.6 ready.
 name     proto    table    state  since       info
-peer2    BGP      master   up     12:06:07    Established
-peer3    BGP      master   up     12:07:07    Established
-device1  Device   master   up     12:05:06    
-direct1  Direct   master   up     12:05:06    
-kernel1  Kernel   master   up     12:05:06    
+kernel1  Kernel   master   up     02:36:03    
+device1  Device   master   up     02:36:03    
+direct1  Direct   master   up     02:36:03    
+peer2    BGP      master   up     02:36:08    Established   
+peer3    BGP      master   up     02:36:07    Established    
 ```
 
 If you see that peer2 and peer3 are "Established", everything is working as expected and we are ready to go. Before we begin playing with this playground, I will provide a brief overview of how BGP works.
@@ -65,87 +58,86 @@ BIRD is a fully-functional routing daemon that supports many different routing p
 Similiar to how we verified that our vagrant environment was provisioned properly, we can view running sessions by running:
 
 ```bash
-root@peer1:~# birdc show protocols                  
-BIRD 1.6.3 ready.         
-name     proto    table    state  since       info  
-peer2    BGP      master   up     00:28:02    Established
-peer3    BGP      master   up     00:28:59    Established 
-device1  Device   master   up     00:28:59        
-direct1  Direct   master   up     00:27:05    
-kernel1  Kernel   master   up     00:27:05          
-```
-
-This gives us a lot of information. However, let us focus on the last two entries, peer2 and peer3. We can see that they are both BGP protocols and that the info field is Established. Each of these entries correspond to a BGP session that peer1 has open with peer2 and peer3. To demonstrate the relationship of these values to our running sessions, let's stop the bird service on peer2.
-
-```bash
-root@peer2:~# systemctl stop bird 
-```
-
-```bash
-root@peer1:~# birdc show protocols
-BIRD 1.6.3 ready.
+root@peer1:/# birdc show protocols
+BIRD 1.6.6 ready.
 name     proto    table    state  since       info
-peer2    BGP      master   up     12:06:07    Active      Socket: Connection refused 
-peer3    BGP      master   up     12:07:07    Established
-device1  Device   master   up     12:05:06   
-direct1  Direct   master   up     12:05:06    
-kernel1  Kernel   master   up     12:05:06    
+kernel1  Kernel   master   up     02:36:02    
+device1  Device   master   up     02:36:02    
+direct1  Direct   master   up     02:36:02    
+peer2    BGP      master   up     02:36:07    Established   
+peer3    BGP      master   up     02:36:06    Established         
 ```
 
-By restarting BIRD on peer2, a peering session should be reestablished.
+This gives us a lot of information. However, let us focus on the last two entries, peer2 and peer3. We can see that they are both BGP protocols and that the info field is Established. Each of these entries correspond to a BGP session that peer1 has open with peer2 and peer3. To demonstrate the relationship of these values to our running sessions, let's stop the bird service on peer2. In a new terminal window run the following to stop peer2, simulating a network failure.
 
 ```bash
-root@peer2:~# systemctl start bird
+ncatelli@ofet> docker-compose stop peer2
+Stopping bird_examples_peer2_1 ... done
 ```
 
 ```bash
-root@peer1:~# birdc show protocols
-BIRD 1.6.3 ready.
+root@peer1:/# birdc show protocols
+BIRD 1.6.6 ready.
 name     proto    table    state  since       info
-peer2    BGP      master   up     00:42:33    Established   
-peer3    BGP      master   up     00:28:59    Established
-device1  Device   master   up     00:27:05    
-direct1  Direct   master   up     00:27:05    
-kernel1  Kernel   master   up     00:27:05    
+kernel1  Kernel   master   up     02:36:02    
+device1  Device   master   up     02:36:02    
+direct1  Direct   master   up     02:36:02    
+peer2    BGP      master   start  02:43:38    Connect       Socket: Connection closed
+peer3    BGP      master   up     02:36:06    Established  
 ```
 
-By stopping the bird daemon on peer2, we have made the TCP connection on port 179 close between peer1 and peer2. Doing this changes our peer session from Established to Active. Established and Active correspond to two of many BGP states, however for the sake of this tutorial we will focus only on Established and consider all other values as not-established. For those more curious, more information on session states can be found in the [wikipedia article on BGP](https://en.wikipedia.org/wiki/Border_Gateway_Protocol#Finite-state_machines).
+By restarting peer2, a BIRD should restart and subsequently the peering session should be reestablished.
+
+```bash
+ncatelli@ofet> docker-compose start peer2
+Starting peer2 ... done
+```
+
+```bash
+root@peer1:/# birdc show protocols
+BIRD 1.6.6 ready.
+name     proto    table    state  since       info
+kernel1  Kernel   master   up     02:36:02    
+device1  Device   master   up     02:36:02    
+direct1  Direct   master   up     02:36:02    
+peer2    BGP      master   up     02:46:29    Established   
+peer3    BGP      master   up     02:36:06    Established    
+```
+
+By stopping the bird daemon on peer2, we have made the TCP connection on port 179 close between peer1 and peer2. Doing this changes our peer session from Established to Connect. Established and Connect correspond to two of many BGP states, however for the sake of this tutorial we will focus only on Established and consider all other values as not-established. For those more curious, more information on session states can be found in the [wikipedia article on BGP](https://en.wikipedia.org/wiki/Border_Gateway_Protocol#Finite-state_machines).
 
 #### Configuring a BGP Session 
 Although we now know how to check whether our session are up in our BGP playground, it's also important to understand how these sessions were configured in the first place. For that, we need to dig into the bird configuration files. Let's look at the configuration files under /etc/bird on peer1.
 
 ```bash
 root@peer1:~# cat /etc/bird/bird.conf
-log syslog all;
-router id 10.0.2.15;
+router id 10.0.0.10;
 
-include "/etc/bird/bird.conf.d/*.conf";
-```
-
-```bash
-root@peer1:~# cat /etc/bird/bird.conf.d/kernel.conf
 protocol kernel {
   metric 0;
+  import none;
   learn;
-  import all;
-  export none; 
+  export all;
 }
-```
 
-```bash
-root@peer1:~# cat /etc/bird/bird.conf.d/device.conf
 protocol device {
 }
-```
 
-```bash
-root@peer1:~# cat /etc/bird/bird.conf.d/bgp_peer2.conf
+protocol direct {
+}
+
 protocol bgp peer2 {
   local as 64512;
   neighbor 10.0.0.11 as 64513;
   import all;
   export all;
 }
+
+protocol bgp peer3 {
+  local as 64512;
+  neighbor 10.0.100.11 as 64514;
+  import all;
+  export all;
 ```
 
 We can see that the configuration required to establish these initial sessions is very minimal. Let's dig deeper into what actually makes this work. For that, we will focus on one specific block. Our protocol bgp peer2 block:
@@ -164,7 +156,7 @@ Earlier in this tutorial, we discussed the difference between eBGP and iBGP and 
 Looking at the next statement, we can see a neighbor statement with both an IP and an additional AS. This IP corresponds to the host, or neighbor in BGP lingo, that we are attempting to establish a session with, while the AS 64513 corresponds to the AS we've assigned to the host, peer2. We can confirm this by looking at the configuration file on peer2.
 
 ```bash
-root@peer2:~# cat /etc/bird/bird.conf.d/bgp_peer1.conf
+root@peer2:/# grep -A4 peer1 /etc/bird/bird.conf
 protocol bgp peer1 {
   local as 64513;
   neighbor 10.0.0.10 as 64512;
@@ -218,29 +210,45 @@ learn;
 Finally, we will set the _learn_ directive which will allow other daemons to learn about routes from the kernel routing table.
 
 #### Discovering direct routes:
-Now that we have configured our BIRD daemons to push routes directly to the kernel routing table, we will need to configure our peers to discover local direct routes. Since we will be adding these routes directly to our loopback interface, let's configure the direct protocol to only use the lo interface.
+Now that we have configured our BIRD daemons to push routes directly to the kernel routing table, we will need to configure our peers to discover local direct routes. Since we will be adding these routes directly to our loopback interface, in your editor of choice, let's configure the direct protocol to only use the lo interface.
 
 ```bash
-root@peer2:~# cat /etc/bird/bird.conf.d/direct.conf
+ncatelli@ofet> grep -A2 direct conf/peer2/etc/bird/bird.conf
 protocol direct {
   interface "lo";
 }
+ncatelli@ofet> docker-compose restart peer2
+Restarting bird_examples_peer2_1 ... done
 ```
 
 Since we also have peer3 on our network, let's do the same on this host to prevent any other routes from being announced.
 
 ```
-root@peer3:~# cat /etc/bird/bird.conf.d/direct.conf
+ncatelli@ofet> grep -A2 direct conf/peer3/etc/bird/bird.conf
 protocol direct {
   interface "lo";
 }
+ncatelli@ofet> docker-compose restart peer3
+Restarting bird_examples_peer3_1 ... done
 ```
 
-At this point, we will have no routes learned or announced, which can be verified with birdc.
+At this point, we will have no routes learned or announced other than our default 10.0.0.0 subnets, which can be verified with birdc.
 
 ```bash
-root@peer2:~# birdc show route all
-BIRD 1.6.3 ready.
+root@peer2:/# birdc show route all
+BIRD 1.6.6 ready.
+10.0.0.0/24        via 10.0.0.10 on eth0 [peer1 03:05:02] ! (100) [AS64512i]
+        Type: BGP unicast univ
+        BGP.origin: IGP
+        BGP.as_path: 64512
+        BGP.next_hop: 10.0.0.10
+        BGP.local_pref: 100
+10.0.100.0/24      via 10.0.0.10 on eth0 [peer1 03:05:02] * (100) [AS64512i]
+        Type: BGP unicast univ
+        BGP.origin: IGP
+        BGP.as_path: 64512
+        BGP.next_hop: 10.0.0.10
+        BGP.local_pref: 100
 ```
 
 #### Filtering imports and exports:
@@ -285,29 +293,34 @@ filter export_subnets {
 and finally we will need to update our protocol bgp peer1 on peer2 to use this export filter.
 
 ```bash
-root@peer2:~# cat /etc/bird/bird.conf.d/bgp_peer1.conf
+root@peer2:/# grep -A4 peer1 /etc/bird/bird.conf
 protocol bgp peer1 {
   local as 64513;
   neighbor 10.0.0.10 as 64512;
-  export filter export_subnets;
+  export filter export_subnets; 
 }
+```
+
+```bash
+ncatelli@ofet> docker-compose restart peer1 peer2
+Restarting bird_examples_peer2_1 ... done
+Restarting bird_examples_peer1_1 ... done
 ```
 
 #### Announcing Routes with BIRD:
 We now have all the building blocks we need to begin announcing routes between peer1 and peer2. Before we do that, let's recap what we have done. To begin, we've configured the BIRD daemon to communicate between its internal routing tables and the kernel routing tables with our kernel protocol. We've configured the BIRD daemon to learn routes from the loopback interface with the direct protocol. We've also configured peer1 to import routes from the other peers and export those routes. Finally we configured peer2 to only export ```192.168.5.5/32``` to peer1 with our export_subnets filter. However, at this point we have no routes currently announced from peer2 to peer1.
 
 ```bash
-root@peer1:~# ip route
-default viia 10.0.2.2 dev eth0
-10.0.0.0/24 dev eth1 proto kernel scope link src 10.0.0.10
-10.0.2.0/24 dev eth0 proto kernel scope link src 10.0.2.15
-10.0.100.0/24 dev eth2 proto kernel scope link src 10.0.100.10
+root@peer1:/# ip route  
+default via 10.0.0.1 dev eth0 
+10.0.0.0/24 dev eth0 proto kernel scope link src 10.0.0.10 
+10.0.100.0/24 dev eth1 proto kernel scope link src 10.0.100.10
 ```
 
 Since we've set up all the building blocks to learn our routes from from the loopback interface. We should be able to directly announce a route by adding an IP to the loopback on peer2.
 
 ```bash
-root@peer2:~# ip a add 192.168.5.5/32 dev lo
+root@peer2:/# ip a add 192.168.5.5/32 dev lo
 ```
 
 Now if we look at both birdc and the kernel routing table on peer1 we should begin to see routes on peer1 to this new IP.
@@ -322,13 +335,13 @@ default viia 10.0.2.2 dev eth0
 ```
 
 ```bash
-root@peer1:~# birdc show route all                                            
-BIRD 1.6.3 ready.
-10.0.0.0/24        dev eth1 [direct1 00:33:24] * (240)     
-        Type: device unicast univ                          
-10.0.100.0/24      dev eth2 [direct1 00:33:24] * (240)     
-        Type: device unicast univ     
-192.168.5.5/32     via 10.0.0.11 on eth1 [peer2 14:11:33] * (100) [AS64513i]
+root@peer1:/# birdc show route all
+BIRD 1.6.6 ready.
+10.0.0.0/24        dev eth0 [direct1 03:10:33] * (240)
+        Type: device unicast univ
+10.0.100.0/24      dev eth1 [direct1 03:10:33] * (240)
+        Type: device unicast univ
+192.168.5.5/32     via 10.0.0.11 on eth0 [peer2 03:12:39] * (100) [AS64513i]
         Type: BGP unicast univ
         BGP.origin: IGP
         BGP.as_path: 64513
@@ -339,55 +352,55 @@ BIRD 1.6.3 ready.
 A ping will show that we can now send traffic to this host from peer1.
 
 ```bash
-root@peer1:~# ping -c 1 192.168.5.5
+root@peer1:/# ping -c 1 192.168.5.5
 PING 192.168.5.5 (192.168.5.5) 56(84) bytes of data.
-64 bytes from 192.168.5.5: icmp_seq=1 ttl=64 time=0.627 ms
+64 bytes from 192.168.5.5: icmp_seq=1 ttl=64 time=0.135 ms
 
 --- 192.168.5.5 ping statistics ---
 1 packets transmitted, 1 received, 0% packet loss, time 0ms
-rtt min/avg/max/mdev = 0.627/0.627/0.627/0.000 ms
+rtt min/avg/max/mdev = 0.135/0.135/0.135/0.000 ms
 ```
 
 We can also see that we can now see that these routes are being announced on to peer3 via peer1.
 
 ```bash
-root@peer3:~# birdc show route all
-BIRD 1.6.3 ready.
-10.0.0.0/24        via 10.0.100.10 on eth1 [peer1 00:34:38] * (100) [AS64512i]
+root@peer3:/# birdc show route all
+BIRD 1.6.6 ready.
+10.0.0.0/24        via 10.0.100.10 on eth0 [peer3 03:10:37] * (100) [AS64512i]
         Type: BGP unicast univ
         BGP.origin: IGP
         BGP.as_path: 64512
         BGP.next_hop: 10.0.100.10
         BGP.local_pref: 100
-10.0.100.0/24      via 10.0.100.10 on eth1 [peer1 00:34:38] ! (100) [AS64512i]
+10.0.100.0/24      via 10.0.100.10 on eth0 [peer3 03:10:37] ! (100) [AS64512i]
         Type: BGP unicast univ
         BGP.origin: IGP
         BGP.as_path: 64512
         BGP.next_hop: 10.0.100.10
         BGP.local_pref: 100
-192.168.5.5/32     via 10.0.0.11 on eth1 [peer1 14:30:34 from 10.0.0.10] * (100) [AS64513i]
+192.168.5.5/32     via 10.0.100.10 on eth0 [peer3 03:12:38] * (100) [AS64513i]
         Type: BGP unicast univ
         BGP.origin: IGP
         BGP.as_path: 64512 64513
-        BGP.next_hop: 10.0.0.11
+        BGP.next_hop: 10.0.100.10
         BGP.local_pref: 100
 ```
 
 ```
-root@peer3:~# ping -c 1 192.168.5.5
+root@peer3:/# ping -c 1 192.168.5.5
 PING 192.168.5.5 (192.168.5.5) 56(84) bytes of data.
-64 bytes from 192.168.5.5: icmp_seq=1 ttl=64 time=0.176 ms
+64 bytes from 192.168.5.5: icmp_seq=1 ttl=63 time=0.082 ms
 
 --- 192.168.5.5 ping statistics ---
 1 packets transmitted, 1 received, 0% packet loss, time 0ms
-rtt min/avg/max/mdev = 0.176/0.176/0.176/0.000 ms
+rtt min/avg/max/mdev = 0.082/0.082/0.082/0.000 ms
 ```
 
 ```
-root@peer3:~# traceroute 192.168.5.5
-traceroute to 192.168.5.5 (192.168.5.5), 30 hops max, 60 byte packets
- 1  10.0.100.10 (10.0.100.10)  0.291 ms  0.206 ms  0.156 ms
- 2  192.168.5.5 (192.168.5.5)  1.132 ms  1.092 ms  1.066 ms
+root@peer3:/# traceroute 192.168.5.5
+traceroute to 192.168.5.5 (192.168.5.5), 64 hops max
+  1   10.0.100.10  0.005ms  0.003ms  0.003ms 
+  2   192.168.5.5  0.003ms  0.003ms  0.003ms
 ```
 
 We can tell this is happening by viewing the AS PATH. By looking at the AS PATH associated with the route in birdc we can see that the route announced from 64513 to 64512 before reaching peer3.

--- a/content/post/intro-to-bgp.md
+++ b/content/post/intro-to-bgp.md
@@ -55,7 +55,7 @@ While BGP is considered an exterior gateway protocol that is used for routing be
 BIRD is a fully-functional routing daemon that supports many different routing protocols, including BGP. BIRD provides a simple configuration format and command line utility for interacting with sessions. BIRD also comes with built-in support for both IPv4 and IPv6 and the respective tools to work with both protocols. 
 
 #### Examining Sessions:
-Similiar to how we verified that our vagrant environment was provisioned properly, we can view running sessions by running:
+Similiar to how we verified that our docker environment was provisioned properly, we can view running sessions by running:
 
 ```bash
 root@peer1:/# birdc show protocols


### PR DESCRIPTION
This PR updates the BGP post to use a new bird_examples_docker playground instead of the old vagrant/chef playground.