### PR TITLE
version bump to latest hugo.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,8 +2,11 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
+ARG HUGOVERSION='0.73.0'
+FROM debian:10
 
-FROM ncatelli/hugo_builder:v0.29
+LABEL maintainer="Nate Catelli <ncatelli@packetfire.org>"
+LABEL description="The hugo build environment for the packetfire site."
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
@@ -15,13 +18,20 @@ ENV DEBIAN_FRONTEND=noninteractive
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
+ARG HUGOVERSION
 
 # Configure apt, install packages and tools
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git iproute2 procps lsb-release \
+    && apt-get -y install git iproute2 procps lsb-release curl \
+    #
+    # Add Hugo
+    && curl -sk "https://github.com/gohugoio/hugo/releases/download/v${HUGOVERSION}/hugo_${HUGOVERSION}_Linux-64bit.tar.gz" -L -o /tmp/hugo.tar.gz \
+    && tar -zxf /tmp/hugo.tar.gz -C /tmp/ \
+    && mv /tmp/hugo /usr/local/bin/hugo \
+    && rm -rf /tmp/* \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json or the definition README at
 // https://github.com/microsoft/vscode-dev-containers/tree/master/containers/go
 {
-	"name": "Hugo v0.29",
+	"name": "Hugo",
 	"dockerFile": "Dockerfile",
 	"runArgs": [
 		// Uncomment the next line to use a non-root user. On Linux, this will prevent

--- a/.github/actions/hugo_builder/action.yml
+++ b/.github/actions/hugo_builder/action.yml
@@ -5,7 +5,7 @@ inputs:
   hugo_version:
     description: The version of hugo to leverage in the build.
     required: true
-    default: '0.29'
+    default: '0.73.0'
   hugo_command:
     description: The hugo command to run.
     required: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Render Hugo
         uses: ./.github/actions/hugo_builder
         with:
-          hugo_version: 0.29
+          hugo_version: 0.73
       - name: Copy Public Directory to S3
         if: github.ref == 'refs/heads/master'
         uses: jakejarvis/s3-sync-action@v0.5.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Render Hugo
         uses: ./.github/actions/hugo_builder
         with:
-          hugo_version: 0.73
+          hugo_version: "0.73.0"
       - name: Copy Public Directory to S3
         if: github.ref == 'refs/heads/master'
         uses: jakejarvis/s3-sync-action@v0.5.0


### PR DESCRIPTION
This PR deprecates the use of hugo_builder in favor of pulling this into a local dev container that can easily control the version of both testing and publishing from within the repo.

resolves #23 