### PR TITLE
mainspring link was previously pointing at spasm

### DIFF
--- a/content/project/mainspring.md
+++ b/content/project/mainspring.md
@@ -1,7 +1,7 @@
 ---
 title: mainspring
 description: A CPU emulation framework built around, and to support the other tools under, the constraints of the first principles of computing project. 
-projectlink: 'https://github.com/ncatelli/spasm'
+projectlink: 'https://github.com/ncatelli/mainspring'
 tags: ['emulator', '6502', 'assembler']
 type: project
 weight: 1


### PR DESCRIPTION
the mainspring project was pointing -> spasm. this just updates the link.